### PR TITLE
Replace `colored`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 [dependencies]
 bilibili-extractor = { version = "0.1.0", git = "https://github.com/nanashi-1/bilibili-extractor" }
 clap = { version = "4.3.1", features = ["derive"] }
-colored = "2.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ use bilibili_extractor::{
     packager::{package_season, PackageConfig},
 };
 use clap::Parser;
-use colored::Colorize;
+
+use crate::text_code::TextCode;
+
+mod text_code;
 
 #[derive(Parser)]
 struct Arguments {
@@ -40,9 +43,9 @@ pub fn list(download_path: String) -> std::io::Result<()> {
 
             println!(
                 "{}: {}\n{}:\n",
-                "Season Title".green().bold(),
+                "Season Title".as_primary_header(),
                 season_metadata.title,
-                "Episodes".green().bold()
+                "Episodes".as_primary_header()
             );
 
             season_metadata
@@ -52,11 +55,11 @@ pub fn list(download_path: String) -> std::io::Result<()> {
             season_metadata.episodes.iter().for_each(|e| {
                 println!(
                     "{}: {}\n{}: {}\n{}: {:?}\n",
-                    "Episode Title".blue().bold(),
+                    "Episode Title".as_secondary_header(),
                     e.title,
-                    "Episode Index".blue().bold(),
+                    "Episode Index".as_secondary_header(),
                     e.index,
-                    "Episode Path".blue().bold(),
+                    "Episode Path".as_secondary_header(),
                     e.path
                 )
             });

--- a/src/text_code.rs
+++ b/src/text_code.rs
@@ -1,0 +1,27 @@
+use std::fmt::Display;
+
+pub trait TextCode {
+    fn as_primary_header(&self) -> String
+    where
+        Self: Display,
+    {
+        format!("\x1b[1;32m{self}\x1b[0m")
+    }
+
+    fn as_secondary_header(&self) -> String
+    where
+        Self: Display,
+    {
+        format!("\x1b[1;34m{self}\x1b[0m")
+    }
+
+    fn as_error(&self) -> String
+    where
+        Self: Display,
+    {
+        format!("\x1b[1;31m{self}\x1b[0m")
+    }
+}
+
+impl TextCode for String {}
+impl TextCode for &str {}


### PR DESCRIPTION
This change is mainly for the compatibility of other crates like `spinners`.